### PR TITLE
chore: Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,14 @@
 ## Purpose
 
 What is the purpose of this PR?
+
 What is the associated Jira ticket?
+
 If there is no ticket, should there be a new ticket created?
+
+#### If this repository is using conventional commits and squash merging is enabled:
+Format the Pull request title as a conventional commit e.g. "fix: typo in important URL". The PR title will become the commit title after squashing.
+#### Otherwise:
 Use the format {Ticket ID}:{PR Title} for naming this PR. If the ticket doesn't exist, set it to ticket 0.
 
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ What is the associated Jira ticket?
 If there is no ticket, should there be a new ticket created?
 
 #### If this repository is using conventional commits and squash merging is enabled:
-Format the Pull request title as a conventional commit e.g. "fix: typo in important URL". The PR title will become the commit title after squashing.
+Format the Pull request title as a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) e.g. "fix: typo in important URL". The PR title will become the commit title after squashing.
 #### Otherwise:
 Use the format {Ticket ID}:{PR Title} for naming this PR. If the ticket doesn't exist, set it to ticket 0.
 


### PR DESCRIPTION
Change the PR template so it gives correct instructions for repositories that have adopted automatic semver using conventional commits

## Purpose

What is the purpose of this PR? Update the PR guildelines (via the template) so that squash merge commits are compatible with conventional commits, and the information is not lost when squashed.

What is the associated Jira ticket? https://liveviewtech.atlassian.net/browse/INFRA-1544

## Approach

How did you go about approaching the Jira acceptance criteria?
What noteworthy changes did you make that reviewers should be aware of?
Did you add new packages or change configurations?
Did you deviate from the original criteria of the Jira ticket?

This whole "Approach" section seems dubious to me, but I'm not here to fix that today.

## Questions

What feedback are you looking for from reviewers, general or do you have specific questions?
- Is the modified Purpose section clear?
- Is the new guideline adequate for both repositories that are using conventional commits, and those that are not?

## TO-DOs
 N/A


## Comments
